### PR TITLE
Fix typo in bin/setup that prevented yarn from installing

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -14,7 +14,7 @@ FileUtils.chdir APP_ROOT do
   system("bundle check") || system!("bundle install")
 
   puts "\n== Installing JavaScript dependencies =="
-  system("bundle check") || system!("bundle install")
+  system("yarn check") || system!("yarn install")
 
   puts "\n== Copying sample files =="
   FileUtils.cp ".tmuxinator.yml.sample", ".tmuxinator.yml" unless File.exist?(".tmuxinator.yml")


### PR DESCRIPTION
Fix typo in `bin/setup` where I repeated the bundle install process instead of installing yarn deps.